### PR TITLE
docs: add observability options to check and run references

### DIFF
--- a/docs/reference/commands/check.md
+++ b/docs/reference/commands/check.md
@@ -56,6 +56,27 @@ Do not use `check` when the real question is “why is one key behaving this way
 
 Do not use `check` when you need a generated dotenv file or subprocess environment. It validates; it does not project.
 
+
+## Observability options
+
+`check` supports optional observability flags to make validation flow easier to inspect while troubleshooting.
+
+* `--trace` enables trace output for validation stages
+* `--trace-format human|jsonl` selects trace output format (`human` by default)
+* `--trace-output stderr|file|both` controls destination (`stderr` by default)
+* `--trace-file PATH` writes traces to a file when output includes `file`
+* `--profile-observability` includes profile-selection and profile-loading trace details
+* `--debug-errors` includes extra error context intended for diagnosis
+
+These options do **not** change validation rules, selected scope, or exit behavior. They only increase visibility into what `check` is already doing.
+
+## Observability examples
+
+```bash
+envctl check --trace
+envctl check --trace --trace-format jsonl
+```
+
 ## Typical examples
 
 ```bash

--- a/docs/reference/commands/run.md
+++ b/docs/reference/commands/run.md
@@ -62,6 +62,26 @@ For container workflows, prefer an explicit env-file handoff such as:
 docker run --env-file <(envctl export --format dotenv) my-image
 ```
 
+
+## Observability options
+
+`run` also supports optional observability flags for debugging projection flow:
+
+* `--trace` enables trace output for resolution and projection stages
+* `--trace-format human|jsonl` selects trace output format (`human` by default)
+* `--trace-output stderr|file|both` controls destination (`stderr` by default)
+* `--trace-file PATH` writes traces to a file when output includes `file`
+* `--profile-observability` includes profile-selection and profile-loading trace details
+* `--debug-errors` includes extra error context intended for diagnosis
+
+These options do **not** change projected values or subprocess behavior. They only add visibility into how `run` resolves and injects environment data.
+
+## Observability examples
+
+```bash
+envctl run --trace --profile-observability -- python app.py
+```
+
 ## Typical examples
 
 ```bash


### PR DESCRIPTION
### Motivation

- Add user-facing documentation for observability flags so operators can inspect validation and projection flows when troubleshooting. 
- Provide realistic usage examples and make explicit that observability only affects visibility, not functional behavior.

### Description

- Added an `Observability options` section to `docs/reference/commands/check.md` documenting `--trace`, `--trace-format human|jsonl`, `--trace-output stderr|file|both`, `--trace-file PATH`, `--profile-observability`, and `--debug-errors`.
- Added an `Observability options` section to `docs/reference/commands/run.md` with the same flags and guidance specific to projection flow.
- Added realistic examples including `envctl check --trace`, `envctl check --trace --trace-format jsonl`, and `envctl run --trace --profile-observability -- python app.py`.
- Clarified in both docs that observability flags do not change validation or projection behavior and only increase visibility into the existing flow.

### Testing

- Ran `git diff --check` to validate there are no whitespace/patch-format issues and it completed successfully.
- This is a documentation-only change, so no unit/integration tests were required or run against runtime code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7dbf514f08332b9ce1749b12da533)